### PR TITLE
Fix htttp:// typo in Docker and Ollama provider tutorials

### DIFF
--- a/docs/tutorial-ai-providers/docker.md
+++ b/docs/tutorial-ai-providers/docker.md
@@ -30,7 +30,7 @@ Official website https://docs.docker.com
 
 - Pick the `Local Models` and select `Docker` as `Provider`.
 - Use the models available directly.
-- Paste the link of the server where the model is running. For localhost: `htttp://localhost:12434`. 
+- Paste the link of the server where the model is running. For localhost: `http://localhost:12434`. 
 - Click outside the options and ask to chat.
 
 <p align="center"><img width="550" height="400" src="https://github.com/user-attachments/assets/77c4631c-5cec-4594-8d5b-6775866231d1"/></p>

--- a/docs/tutorial-ai-providers/ollama.md
+++ b/docs/tutorial-ai-providers/ollama.md
@@ -31,7 +31,7 @@ Opensource project to run, create, and share large language models (LLMs).
 
 - Pick the `Local LLMs` and select `Ollama` as `Provider`.
 - Use the models available directly.
-- Paste the link of the server where the model is running. For localhost: `htttp://localhost:11434`. 
+- Paste the link of the server where the model is running. For localhost: `http://localhost:11434`. 
 - Click outside the options and ask to chat.
 
 <p align="center"><img width="537" height="771" alt="image" src="https://github.com/user-attachments/assets/6471e45a-b971-41cf-9033-fbf538c1e800" /></p>


### PR DESCRIPTION
Both `docs/tutorial-ai-providers/docker.md` (line 33) and `docs/tutorial-ai-providers/ollama.md` (line 34) instruct users to paste `htttp://localhost:12434` / `htttp://localhost:11434` (extra t) into the provider URL field. As written, this URL would fail. Fixed both to `http://`.